### PR TITLE
Added support for redirecting to the web

### DIFF
--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -42,6 +42,7 @@ normative:
   RFC8259:
   RFC8414:
   RFC8707:
+  RFC9126:
   RFC9449:
   I-D.ietf-oauth-step-up-authn-challenge:
   OpenID.Native-SSO:

--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -290,16 +290,16 @@ For example,
 
 ### Redirect Response
 
-In the case where the authorization server wishes to interact with the 
-user directly, it can return the redirect response. The authorization 
-server may choose to interact directly with the user based on a risk 
+In the case where the authorization server wishes to interact with the
+user directly, it can return the redirect response. The authorization
+server may choose to interact directly with the user based on a risk
 assesment, the introduction of a new authentication method not supported
 in the applicatio, or to handle an exception flow like account recovery.
-In this case the client is expected to initiate a traditional OAuth 
+In this case the client is expected to initiate a traditional OAuth
 Authorization Code flow with PKCE according to {{RFC6749}} and {{RFC7636}}.
 
 "redirect":
-: REQUIRED. A Pushed Authroization Request (PAR) response as defined in 
+: REQUIRED. A Pushed Authroization Request (PAR) response as defined in
 Section 2.2 of {{RFC9126}}. The request_uri parameter contains the URI that
 the native client should redirect the user to.
 

--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -292,7 +292,7 @@ For example,
 ### Redirect Response
 
 In the case where the authorization server wishes to interact with the
-user directly, it can return the redirect response. The authorization
+user directly, it can return the `redirect` response. The authorization
 server may choose to interact directly with the user based on a risk
 assesment, the introduction of a new authentication method not supported
 in the application, or to handle an exception flow like account recovery.

--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -302,7 +302,7 @@ Authorization Code flow with PKCE according to {{RFC6749}} and {{RFC7636}}.
 "redirect":
 : REQUIRED. A Pushed Authroization Request (PAR) response as defined in
 Section 2.2 of {{RFC9126}}. The request_uri parameter contains the URI that
-the native client should redirect the user to.
+the client should use in the authorization request.
 
 ### Error Response {#challenge-error-response}
 

--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -538,7 +538,7 @@ A user may be redirected to the Authorization Server to perfrom an account reset
 * The Authorization Server verifies the username and determines that the account is locked and returns a Redirect message.
 * The Client parses the redirect message, opens a browser and redirects the user to the Authorization Server performing an OAuth 2.0 flow with PKCE.
 * The user resets their account by performing a multi-step authentication flow with the Authorization Server.
-* The Authorization Server issues an Authorizaton Code, which is exchanged for an access and refresh token bfore returning control to the Client.
+* The Authorization Server issues an Authorizaton Code, which is exchanged for an access and refresh token before returning control to the Client.
 
 ## Passwordless One-Time Passwork (OTP)
 

--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -295,7 +295,7 @@ In the case where the authorization server wishes to interact with the
 user directly, it can return the redirect response. The authorization
 server may choose to interact directly with the user based on a risk
 assesment, the introduction of a new authentication method not supported
-in the applicatio, or to handle an exception flow like account recovery.
+in the application, or to handle an exception flow like account recovery.
 In this case the client is expected to initiate a traditional OAuth
 Authorization Code flow with PKCE according to {{RFC6749}} and {{RFC7636}}.
 

--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -288,6 +288,20 @@ For example,
       "authorization_code": "uY29tL2F1dGhlbnRpY"
     }
 
+### Redirect Response
+
+In the case where the authorization server wishes to interact with the 
+user directly, it can return the redirect response. The authorization 
+server may choose to interact directly with the user based on a risk 
+assesment, the introduction of a new authentication method not supported
+in the applicatio, or to handle an exception flow like account recovery.
+In this case the client is expected to initiate a traditional OAuth 
+Authorization Code flow with PKCE according to {{RFC6749}} and {{RFC7636}}.
+
+"redirect":
+: REQUIRED. A Pushed Authroization Request (PAR) response as defined in 
+Section 2.2 of {{RFC9126}}. The request_uri parameter contains the URI that
+the native client should redirect the user to.
 
 ### Error Response {#challenge-error-response}
 
@@ -513,6 +527,17 @@ IANA has (TBD) registered the following values in the IANA "OAuth Authorization 
 # Example User Experiences
 
 This section provides non-normative examples of how this specification may be used to support specific use cases.
+
+## Redirect to Authorization Server
+
+A user may be redirected to the Authorization Server to perfrom an account reset.
+
+* The Client collects username from the user.
+* The Client sends an Authorization Challenge Request ({{challenge-request}}) to the Authorization Challenge Endpoint ({{authorization-challenge-endpoint}}) including the username.
+* The Authorization Server verifies the username and determines that the account is locked and returns a Redirect message.
+* The Client parses the redirect message, opens a browser and redirects the user to the Authorization Server performing an OAuth 2.0 flow with PKCE.
+* The user resets their account by performing a multi-step authentication flow with the Authorization Server.
+* The Authorization Server issues an Authorizaton Code, which is exchanged for an access and refresh token bfore returning control to the Client.
 
 ## Passwordless One-Time Passwork (OTP)
 


### PR DESCRIPTION
Added option for redirecting to the web.

Notes: 

1. Re-using the PAR response - feels strange to have the "request_uri" parameter as the redirect URI - is that OK?
2. Added and example of redirecting to the web. Not entirely sure how control gets passed back to the "native" app/client or how much detail we should provide.