### PR TITLE
Clarified two ways in which phishing may increase

### DIFF
--- a/draft-parecki-oauth-first-party-apps.md
+++ b/draft-parecki-oauth-first-party-apps.md
@@ -568,9 +568,8 @@ This specification is not prescriptive on how the Authorization Server establish
 
 There are two ways using this specification increases the risk of phishing.
 
-With this specification, the client interacts directly with the end user, collecting information provided by the user and sending it to the authorization server. If an attacker impersonates the client and successfully tricks a user into using it, they may not realize they are giving their credentials to the malicious application.
-
-In a traditional OAuth deployment using the redirect-based authorization code flow, the user will only ever enter their credentials at the authorization server, and it is straightforward to explain to avoid entering credentials in other "fake" websites. By introducing a new place the user is expected to enter their credentials using this specification, it is more complicated to teach users how to recognize other fake login prompts that might be attempting to steal their credentials.
+1. Malicious application: With this specification, the client interacts directly with the end user, collecting information provided by the user and sending it to the authorization server. If an attacker impersonates the client and successfully tricks a user into using it, they may not realize they are giving their credentials to the malicious application.
+2. User education: In a traditional OAuth deployment using the redirect-based authorization code flow, the user will only ever enter their credentials at the authorization server, and it is straightforward to explain to avoid entering credentials in other "fake" websites. By introducing a new place the user is expected to enter their credentials using this specification, it is more complicated to teach users how to recognize other fake login prompts that might be attempting to steal their credentials.
 
 Because of these risks, the authorization server MAY decide to require that the user go through a redirect-based flow at any stage of the process based on its own risk assessment.
 


### PR DESCRIPTION
Clarifying the text to make it clear that there are two ways in which phishing attacks may be facilitated by this specification. (see issue #81)

cc @yaronf