### PR TITLE
Enhance security description for authorization challenge

### DIFF
--- a/draft-ietf-oauth-first-party-apps.md
+++ b/draft-ietf-oauth-first-party-apps.md
@@ -587,7 +587,7 @@ The authorization challenge endpoint is capable of directly receiving user crede
 
 An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in browser-based authentication flows. Implementors SHOULD consider similar security measures to reduce this risk in the authorization challenge endpoint. Additionally, the attestation APIs SHOULD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
 
-For low-entropy inputs like OTPs, implementors SHOULD rate-limit requests from the same `auth_session`.
+Implementors SHOULD rate-limit requests from the same `auth_session`.
 
 ## Client Authentication {#client-authentication}
 

--- a/draft-ietf-oauth-first-party-apps.md
+++ b/draft-ietf-oauth-first-party-apps.md
@@ -583,9 +583,11 @@ Because of these risks, the authorization server MAY decide to require that the 
 
 ## Credential Stuffing Attacks {#credential-attacks}
 
-The authorization challenge endpoint is capable of directly receiving user credentials and returning authorization codes. This exposes a new vector to perform credential stuffing attacks, if additional measures are not taken to ensure the authenticity of the application.
+The authorization challenge endpoint is capable of directly receiving user credentials and/or low-entropy values like OTPs. This exposes a new vector to perform credential stuffing or brute force attacks if additional measures are not taken to ensure the authenticity of the application.
 
 An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in browser-based authentication flows. Implementors SHOULD consider similar security measures to reduce this risk in the authorization challenge endpoint. Additionally, the attestation APIs SHOULD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
+
+For low-entropy inputs like OTPs, implementors SHOULD rate-limit requests from the same `auth_session`.
 
 ## Client Authentication {#client-authentication}
 

--- a/draft-ietf-oauth-first-party-apps.md
+++ b/draft-ietf-oauth-first-party-apps.md
@@ -583,7 +583,7 @@ Because of these risks, the authorization server MAY decide to require that the 
 
 ## Credential Stuffing Attacks {#credential-attacks}
 
-The authorization challenge endpoint is capable of directly receiving user credentials and/or low-entropy values like OTPs. This exposes a new vector to perform credential stuffing or brute force attacks if additional measures are not taken to ensure the authenticity of the application.
+The authorization challenge endpoint is capable of directly receiving user credentials and other authentication material like OTPs. This exposes a new vector to perform credential stuffing or brute force attacks if additional measures are not taken to ensure the authenticity of the application.
 
 An authorization server may already have a combination of built-in or 3rd party security tools in place to monitor and reduce this risk in browser-based authentication flows. Implementors SHOULD consider similar security measures to reduce this risk in the authorization challenge endpoint. Additionally, the attestation APIs SHOULD be used when possible to assert a level of confidence to the authorization server that the request is originating from an application owned by the same party.
 


### PR DESCRIPTION
Clarified the risks associated with the authorization challenge endpoint by specifying that it can receive low-entropy values like OTPs, and emphasized the need for rate-limiting on such inputs.

For #138