### PR TITLE
Clarify protection of auth_session value

### DIFF
--- a/draft-ietf-oauth-first-party-apps.md
+++ b/draft-ietf-oauth-first-party-apps.md
@@ -470,7 +470,7 @@ rather than the Authorization Challenge Endpoint.
 
 The `auth_session` is a value that the authorization server issues in order to be able to associate subsequent requests from the same client. It is intended to be analagous to how a browser cookie associates multiple requests by the same browser to the authorization server.
 
-The `auth_session` value is completely opaque to the client, and as such the authorization server MUST adequately protect the value from inspection by the client, for example by using a random string or using a JWE if the authorization server is not maintaining state on the backend.
+The `auth_session` value is completely opaque to the client, and as such the authorization server MUST adequately protect the value from inspection by the client.
 
 If the client has an `auth_session`, the client MUST include it in future requests to the authorization challenge endpoint. The client MUST store the `auth_session` beyond the issuance of the authorization code to be able to use it in future requests.
 


### PR DESCRIPTION
Removed the example of using a random string or JWE for protecting the auth_session value. Addresses issue #107