### PR TITLE
Update 'response_type' requirements in documentation

### DIFF
--- a/draft-ietf-oauth-first-party-apps.md
+++ b/draft-ietf-oauth-first-party-apps.md
@@ -280,7 +280,7 @@ format with a character encoding of UTF-8 in the HTTP request body:
   See {{redirect-to-web}} for details.
 
 "response_type":
-: REQUIRED. Per section 3.1.1 of {{RFC6749}} `response_type` is required and for this specification MUST contain the value of `code`.
+: REQUIRED. Per section 3.1.1 of {{RFC6749}} `response_type` is required, and for this specification MUST contain the value of `code`.
 
 Specific implementations as well as extensions to this specification MAY define additional parameters to be used at this endpoint.
 

--- a/draft-ietf-oauth-first-party-apps.md
+++ b/draft-ietf-oauth-first-party-apps.md
@@ -279,6 +279,9 @@ format with a character encoding of UTF-8 in the HTTP request body:
 : OPTIONAL. The code challenge method as defined by {{RFC7636}}.
   See {{redirect-to-web}} for details.
 
+"response_type":
+: REQUIRED. Per section 3.1.1 of {{RFC6749}} `response_type` is required and for this specification MUST contain the value of `code`.
+
 Specific implementations as well as extensions to this specification MAY define additional parameters to be used at this endpoint.
 
 For example, the client makes the following request to initiate a flow


### PR DESCRIPTION
Clarify the requirements for 'response_type' in OAuth specification. Addresses issue #113.